### PR TITLE
Remove unnecessary amount rounding

### DIFF
--- a/src/marginTrading/simple/mtOrderForm.ts
+++ b/src/marginTrading/simple/mtOrderForm.ts
@@ -35,7 +35,6 @@ import {
   toOrderbookChange$, TotalFieldChange,
   transactionToX
 } from '../../utils/form';
-import { formatPriceDown, formatPriceUp } from '../../utils/formatters/format';
 import { description, Impossible, isImpossible } from '../../utils/impossible';
 import { firstOfOrTrue } from '../../utils/operators';
 import { minusOne, one, zero } from '../../utils/zero';
@@ -417,11 +416,8 @@ function addAmount(total: BigNumber | undefined, state: MTSimpleFormState): MTSi
   return {
     ...state,
     total,
+    amount,
     messages: state.messages.filter(m => m.kind !== MessageKind.impossibleCalculateTotal),
-    amount: amount ?
-      new BigNumber(state.kind === OfferType.buy ?
-        formatPriceDown(amount, state.baseToken) : formatPriceUp(amount, state.baseToken)
-      ) : undefined,
   };
 }
 


### PR DESCRIPTION
There is no need to round this amount here. It breaks amounts that are calculated in setMax method, and it's being handled on the input level to display proper decimal rounding.