### PR TITLE
Fix gas price calculations

### DIFF
--- a/src/blockchain/network.ts
+++ b/src/blockchain/network.ts
@@ -118,7 +118,7 @@ export type GasPrice$ = Observable<BigNumber>
 export const gasPrice$: GasPrice$ = onEveryBlock$.pipe(
   switchMap(() => bindNodeCallback(web3.eth.getGasPrice)()),
   map((x) => new BigNumber(x)),
-  map((x) => x.multipliedBy(1.25)),
+  map((x) => x.multipliedBy(1.25).decimalPlaces(0, 0)),
   distinctUntilChanged((x: BigNumber, y: BigNumber) => x.eq(y)),
   shareReplay(1),
 )


### PR DESCRIPTION
Issue posted [here](https://github.com/OasisDEX/oasis/issues/453)

Gas price pipeline has mapping that multiplies this value by `1.25` factor. For some values (e.g. 9240000233) we might get value with a fraction. In further operations it's being converted to a number and to BigNumber again which fails (decimals are not supported in BN). Rounding this value at the beginning resolves this issue.