### PR TITLE
Change 'Account' to 'Balances' in Market message

### DIFF
--- a/src/exchange/offerMake/OfferMakeForm.tsx
+++ b/src/exchange/offerMake/OfferMakeForm.tsx
@@ -587,8 +587,8 @@ function messageContent(msg: Message) {
           {`Unlock ${msg.token} for Trading in the `}
           <routerContext.Consumer>
             {({ rootUrl }) => (
-              <Link to={`${rootUrl}account`} style={{ whiteSpace: 'nowrap' }}>
-                Account Page
+              <Link to={`${rootUrl}balances`} style={{ whiteSpace: 'nowrap' }}>
+                Balances Page
               </Link>
             )}
           </routerContext.Consumer>


### PR DESCRIPTION
Wrong message saying `Account` instead of `Balance` page
<img width="243" alt="Screen Shot 2020-07-10 at 16 00 38" src="https://user-images.githubusercontent.com/603495/87163249-5810d500-c2c7-11ea-837e-e07d2db3188b.png">
