### PR TITLE
Disable Mixpanel tracking when there is no account connected

### DIFF
--- a/src/blockchain/network.ts
+++ b/src/blockchain/network.ts
@@ -66,8 +66,10 @@ combineLatest(account$, context$)
     }),
   )
   .subscribe(([account, network]) => {
-    mixpanelIdentify(account!, { walletType: 'metamask' });
-    trackingEvents.accountChange(account!, network!);
+    if (account) {
+      mixpanelIdentify(account, { walletType: 'metamask' });
+      trackingEvents.accountChange(account, network!);
+    }
   });
 
 export const onEveryBlock$ = combineLatest(every5Seconds$, context$).pipe(


### PR DESCRIPTION
According to Mixpanel recommendation: `We recommend against using identify for anonymous visitors to your site.` [https://developer.mixpanel.com/docs/javascript#identify](Mixpanel identify docs)