### PR TITLE
TECH-1124 - Upgrading Node.js 12 (End-of-Life) Github Actions to Node.js 16

### DIFF
--- a/.github/workflows/aws-prod.yml
+++ b/.github/workflows/aws-prod.yml
@@ -15,10 +15,10 @@ jobs:
       CF_DISTRIBUTION_ID: E1WAM5PXGL64FP
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
 
     - name: Setup Node Version
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: '10.19'
 

--- a/.github/workflows/aws-staging.yml
+++ b/.github/workflows/aws-staging.yml
@@ -15,10 +15,10 @@ jobs:
       CF_DISTRIBUTION_ID: E3SWP538EXVDQ5
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
 
     - name: Setup Node Version
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: '10.19'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Node Version
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '10.19'
 
@@ -20,7 +20,7 @@ jobs:
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ${{ steps.yarn-cache-dir-path.outputs.dir }}


### PR DESCRIPTION
TECH-1124 - Node.js 12 Github Actions are deprecated as Node.js 12 reached End-of-Life on April 2022. This PR upgrades them to Node.js 16